### PR TITLE
Updated saved search so we can add arbitrary parameters - specifically the bq parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 from setuptools import find_packages
 
 setup(
-    name = "saved_search",
-    version = "0.2",
-    description = "User-defined, persistent searches for Django-Haystack.",
-    author = "Matt DeBoard",
-    author_email = "matt@directemployers.com",
+    name="saved_search",
+    version="0.3",
+    description="User-defined, persistent searches for Django-Haystack.",
+    author="Matt DeBoard",
+    author_email="matt@directemployers.com",
     packages=find_packages(),
-    classifiers = [
+    classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
We're still overwriting kwargs, so passing in arbitrary parameters still won't work, but it gets what we need to get done working. Really most of this isn't necessary with the recent updates to haystack/pysolr.

All tests on microsites pass.
